### PR TITLE
Make each page scrollable

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -1,14 +1,39 @@
+const template = document.createElement('template');
+template.innerHTML = /* html */ `
+  <style>
+    :host {
+      display: block;
+      height: 100%;
+    }
+
+    .container, canvas { width: 100%; }
+
+    .container {
+      overflow-y: scroll;
+      scroll-behavior: smooth;
+      overflow-x: hidden;
+      height: 100%;
+    }
+  </style>
+  <div class="container">
+    <canvas></canvas>
+  </div>
+`;
+
+function clone() {
+  return document.importNode(template.content, true);
+}
+
 function wait(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-function init(canvasNode) {
+function init(host) {
   /* DOM variables */
+  let frag = clone();
+  let canvasNode = frag.querySelector('canvas');
   let ctx = canvasNode.getContext('2d');
   let imgNode = document.createElement('img');
-
-  /* State variables */
-  let current = null;
 
   /* DOM update functions */
   function setImgNode(value) {
@@ -22,23 +47,10 @@ function init(canvasNode) {
 
     let w = imgNode.naturalWidth;
     let h = imgNode.naturalHeight;
-    
-    canvasNode.dataset.page = page;
+
     canvasNode.width = w;
     canvasNode.height = h;
     ctx.drawImage(imgNode, 0, 0, w, h);
-  }
-
-  function setCanvasCurrent(value) {
-    canvasNode.classList[value ? 'add' : 'remove']('current');
-  }
-
-  /* State update functions */
-  function setCurrent(value) {
-    if(value !== current) {
-      current = value;
-      setCanvasCurrent(current);
-    }
   }
 
   /* Logic functions */
@@ -62,17 +74,17 @@ function init(canvasNode) {
   /* Event dispatchers */
   function dispatchNavPrevious() {
     let ev = new CustomEvent('nav-previous');
-    canvasNode.dispatchEvent(ev);
+    host.dispatchEvent(ev);
   }
 
   function dispatchNavNext() {
     let ev = new CustomEvent('nav-next');
-    canvasNode.dispatchEvent(ev);
+    host.dispatchEvent(ev);
   }
 
   function dispatchControls() {
     let ev = new CustomEvent('controls');
-    canvasNode.dispatchEvent(ev);
+    host.dispatchEvent(ev);
   }
 
   /* Event listeners */
@@ -95,23 +107,38 @@ function init(canvasNode) {
 
   function update(data = {}) {
     if(data.url) return setCanvasURL(data.url, data.page);
-    if(data.current != null) setCurrent(data.current);
-    return canvasNode;
+    return frag;
   }
 
-  Object.defineProperties(update, {
-    connect: {
-      value: connect
-    },
-    disconnect: {
-      value: disconnect
-    },
-    node: {
-      value: canvasNode
-    }
-  });
+  update.connect = connect;
+  update.disconnect = disconnect;
 
   return update;
 }
 
-export default init;
+const VIEW = Symbol('view');
+
+class ComicReaderPage extends HTMLElement {
+  constructor() {
+    super();
+    this.attachShadow({ mode: 'open' });
+    this[VIEW] = init(this);
+  }
+
+  connectedCallback() {
+    let update = this[VIEW];
+    if(!this.shadowRoot.firstChild)
+      this.shadowRoot.appendChild(update());
+    update.connect();
+  }
+
+  disconnectedCallback() {
+    this[VIEW].disconnect();
+  }
+
+  set url(url) {
+    this[VIEW]({ url });
+  }
+}
+
+customElements.define('comic-reader-page', ComicReaderPage);


### PR DESCRIPTION
This fixes an issue where when moving to the next page, the page would
be shown with the same scroll position as the previous page. This was
because all pages used the same scroll container.

This makes it so that each page is in its own scroll container. So when
you transition to the next page it will be at the top.