### PR TITLE
Reset zoom/panning when loading new pages

### DIFF
--- a/lib/page.js
+++ b/lib/page.js
@@ -69,6 +69,9 @@ function init(host) {
   let ctx = canvasNode.getContext('2d');
   let imgNode = document.createElement('img');
 
+  /* State variables */
+  let url;
+
   /* DOM update functions */
   function setImgNode(value) {
     imgNode.src = value;
@@ -89,7 +92,6 @@ function init(host) {
   async function setCanvasURL(url) {
     setContainerLoaded(false);
     setImgNode(url);
-    resetZoomPosition();
     await waitOnImg(imgNode);
     await wait(50);
 
@@ -101,6 +103,15 @@ function init(host) {
     ctx.drawImage(imgNode, 0, 0, w, h);
     setContainerLoaded(true);
     dispatchDraw();
+  }
+
+  /* State update functions */
+  function setURL(value) {
+    if(value !== url) {
+      url = value;
+      setCanvasURL(value);
+      resetZoomPosition();
+    }
   }
 
   /* Logic functions */
@@ -161,7 +172,7 @@ function init(host) {
   }
 
   function update(data = {}) {
-    if(data.url) return setCanvasURL(data.url, data.page);
+    if(data.url) return setURL(data.url);
     return frag;
   }
 

--- a/lib/page.js
+++ b/lib/page.js
@@ -65,6 +65,7 @@ function init(host) {
   let frag = clone();
   let containerNode = frag.querySelector('.container');
   let canvasNode = frag.querySelector('canvas');
+  let zoomNode = frag.querySelector('comic-reader-zoom');
   let ctx = canvasNode.getContext('2d');
   let imgNode = document.createElement('img');
 
@@ -77,9 +78,18 @@ function init(host) {
     containerNode.classList[value ? 'add' : 'remove']('loaded');
   }
 
+  function resetZoomPosition() {
+    zoomNode.setTransform({
+      x: 0,
+      y: 0,
+      scale: 1
+    });
+  }
+
   async function setCanvasURL(url) {
     setContainerLoaded(false);
     setImgNode(url);
+    resetZoomPosition();
     await waitOnImg(imgNode);
     await wait(50);
 


### PR DESCRIPTION
When loading a new page, make sure to reset the x/y/scale on
comic-reader-zoom so that when you navigate to this new page it is in
the proper position.