### PR TITLE
Prevent swipe animation when loading the initial page

### DIFF
--- a/index.js
+++ b/index.js
@@ -493,7 +493,7 @@ function init(shadow) {
     rotatePage();
 
     // Dispatch the load event
-    dispatchLoad();
+    setTimeout(dispatchLoad, 0);
   }
 
   function closeBook() {

--- a/index.js
+++ b/index.js
@@ -468,11 +468,8 @@ function init(shadow) {
 
   async function loadPage(i) {
     setProgressContainerNode(true);
-    let url = await source.item(i, setProgressNode);
+    await source.item(i, setProgressNode);
     setProgressContainerNode(false);
-
-    currentReaderPageNode.dataset.page = i;
-    currentReaderPageNode.url = url;
   }
 
   async function loadSrc() {
@@ -493,16 +490,9 @@ function init(shadow) {
     await loadPage(currentPage);
     preloadIdle();
     setCurrentPageNode();
+    rotatePage();
 
-    for(let i = 1; i < 5; i++) {
-      if(source.getLength() > i) {
-        let nextUrl = await source.item(i);
-        let readerPage = readerPageNodes[i];
-        readerPage.dataset.page = i;
-        readerPage.url = nextUrl;
-      }
-    }
-
+    // Dispatch the load event
     dispatchLoad();
   }
 
@@ -530,6 +520,10 @@ function init(shadow) {
   }
 
   function rotatePage() {
+    if(!source) {
+      return;
+    }
+
     disableNav();
     setViewerUpdating(true);
 

--- a/lib/zoom.js
+++ b/lib/zoom.js
@@ -500,8 +500,13 @@ class PinchZoom extends HTMLElement {
     // We only want to track 2 pointers at most
     if (pointerTracker.currentPointers.length === 2 || !this._positioningEl)
         return false;
-    this._undoTransitions();
     event.preventDefault();
+
+    if(this._startScale == null) {
+      this._start = { x: this._transform.e, y: this._transform.f, scale: this._transform.d };
+      this._startScale = this._transform.d;
+    }
+
     this._undoTransitions();
     return true;
   }
@@ -525,11 +530,6 @@ class PinchZoom extends HTMLElement {
       const prevDistance = getDistance(previousPointers[0], previousPointers[1]);
       const newDistance = getDistance(currentPointers[0], currentPointers[1]);
       const scaleDiff = prevDistance ? newDistance / prevDistance : 1;
-
-      if(this._startScale == null) {
-        this._start = { x: this._transform.e, y: this._transform.f, scale: this._transform.d };
-        this._startScale = this._transform.d;
-      }
 
       this._applyChange({
           originX, originY, scaleDiff,


### PR DESCRIPTION
The initial page could be loaded from an attribute or a property.
Previously there was a visible swiping motion. This prevents that by
using rotatePage() to correctly position all of the pages upon the
initial load.