### PR TITLE
Preallocate images

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -290,7 +290,7 @@ function init(shadow) {
   let currentReaderPageNode = readerPageNodes[0];
 
   /* State variables */
-  let src, source, title, totalPages;
+  let src, source, title, totalPages, imgMap;
   let viewerX = 0, navEnabled = true,
   currentPage = 0, nextPage = 0, numberOfItemsLoaded = 0;
 
@@ -366,6 +366,7 @@ function init(shadow) {
   function setSrc(value) {
     if(src !== value) {
       src = value;
+      imgMap = new Map();
       loadSrc();
     }
   }
@@ -443,6 +444,16 @@ function init(shadow) {
     }
   }
 
+  function getImgFromUrl(url) {
+    let img = imgMap.get(url);
+    if(!img) {
+      img = document.createElement('img');
+      img.src = url;
+      imgMap.set(url, img);
+    }
+    return img;
+  }
+
   /* Logic functions */
   async function preloadIdle() {
     requestIdleCallback(preload);
@@ -461,8 +472,9 @@ function init(shadow) {
 
   async function loadInto(i, readerPage) {
     let url = await source.item(i);
+    let img = getImgFromUrl(url);
     readerPage.dataset.page = i;
-    readerPage.url = url;
+    readerPage.image = img;
   }
 
   async function loadPage(i) {
@@ -498,6 +510,7 @@ function init(shadow) {
   function closeBook() {
     if(source && source.close) {
       source.close();
+      imgMap = null;
     }
   }
 

--- a/src/page.js
+++ b/src/page.js
@@ -70,14 +70,15 @@ function init(host) {
   let canvasNode = frag.querySelector('canvas');
   let zoomNode = frag.querySelector('comic-reader-zoom');
   let ctx = canvasNode.getContext('2d');
-  let imgNode = document.createElement('img');
-
-  /* State variables */
-  let url;
+  let imgNode;
 
   /* DOM update functions */
-  function setImgNode(value) {
-    imgNode.src = value;
+  function setImg(value) {
+    if(value !== imgNode) {
+      imgNode = value;
+      drawCanvas();
+      resetZoomPosition();
+    }
   }
 
   function setContainerLoaded(value) {
@@ -92,9 +93,8 @@ function init(host) {
     });
   }
 
-  async function setCanvasURL(url) {
+  async function drawCanvas() {
     setContainerLoaded(false);
-    setImgNode(url);
     await waitOnImg(imgNode);
     await wait(50);
 
@@ -105,15 +105,6 @@ function init(host) {
     canvasNode.height = h;
     ctx.drawImage(imgNode, 0, 0, w, h);
     setContainerLoaded(true);
-  }
-
-  /* State update functions */
-  function setURL(value) {
-    if(value !== url) {
-      url = value;
-      setCanvasURL(value);
-      resetZoomPosition();
-    }
   }
 
   /* Logic functions */
@@ -169,7 +160,7 @@ function init(host) {
   }
 
   function update(data = {}) {
-    if(data.url) return setURL(data.url);
+    if(data.image) setImg(data.image);
     return frag;
   }
 
@@ -199,8 +190,8 @@ class ComicReaderPage extends HTMLElement {
     this[VIEW].disconnect();
   }
 
-  set url(url) {
-    this[VIEW]({ url });
+  set image(image) {
+    this[VIEW]({ image });
   }
 }
 


### PR DESCRIPTION
This changes it so that images are preallocated rather than just keeping
the URLs. This means that we don't have to wait on an image to load each
time we cycle through pages. However we do still recycle the use of the
canvases.

For now we are not preallocating *all* images. This is because some
books can be large (500+ pages perhaps) and I'm worried about using up
that much memory.