### PR TITLE
Fix navigation events when zoomed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 11
 before_install:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"

--- a/src/page.js
+++ b/src/page.js
@@ -119,9 +119,11 @@ function init(host) {
   }
 
   function getClickPosition(ev) {
-    let w = canvasNode.offsetWidth;
-    let third = w / 3;
-    let x = ev.offsetX;
+    let { left, width } = containerNode.getBoundingClientRect();
+    let pageX = ev.pageX;
+    let x = pageX - left;
+
+    let third = width / 3;
     return x < third ? 0 : x > (third * 2) ? 2 : 1;
   }
 

--- a/src/zoom.js
+++ b/src/zoom.js
@@ -560,6 +560,10 @@ class PinchZoom extends HTMLElement {
         scale: scale < 1 ? 1 : scale
       });
     } else {
+      if(this._start == null) {
+        this._makeStart();
+      }
+
       const { x: startX, y: startY, scale: startScale } = this._start;
       const duration = Date.now() - this._startTime;
 


### PR DESCRIPTION
When zoomed in, navigation events should work the same as when zoomed
out; clicking in the middle should show the controls.

This fixes it by calculating the position of the reader from within the
page, and using pageX to determine where it was clicked (rather than
    relying on clientX).